### PR TITLE
mLUKE の Pretraining 関する記述を追加

### DIFF
--- a/luke/cli.py
+++ b/luke/cli.py
@@ -23,6 +23,7 @@ import luke.pretraining.train
 import luke.utils.entity_vocab
 import luke.utils.interwiki_db
 import luke.utils.model_utils
+import luke.utils.convert_luke_to_huggingface_model
 
 
 @click.group()
@@ -61,6 +62,7 @@ cli.add_command(luke.pretraining.train.compute_total_training_steps)
 cli.add_command(luke.utils.interwiki_db.build_interwiki_db)
 cli.add_command(luke.utils.entity_vocab.build_multilingual_entity_vocab)
 cli.add_command(luke.utils.model_utils.create_model_archive)
+cli.add_command(luke.utils.convert_luke_to_huggingface_model.convert_luke_to_huggingface_model)
 
 
 if __name__ == "__main__":

--- a/luke/pretraining/train.py
+++ b/luke/pretraining/train.py
@@ -130,9 +130,16 @@ def load_state_dict(state_dict: dict, model: LukePretrainingModel, config: LukeC
 @click.option("--train-batch-size", type=int, required=True)
 @click.option("--num-epochs", type=int, required=True)
 def compute_total_training_steps(dataset_dir, train_batch_size, num_epochs):
-    datasets = load_dataset(dataset_dir)
-    dataset_size = sum([len(d) for d in datasets])
-    train_steps = math.ceil(dataset_size / train_batch_size * num_epochs)
+    dataset_directories = glob.glob(dataset_dir)
+    if len(dataset_directories) == 0:
+        raise ValueError(f"{dataset_dir} does not match any directory.")
+
+    total_dataset_size = 0
+    for dataset_dir in dataset_directories:
+        datasets = load_dataset(dataset_dir)
+        dataset_size = sum([len(d) for d in datasets])
+        total_dataset_size += dataset_size
+    train_steps = math.ceil(total_dataset_size / train_batch_size * num_epochs)
     print("Total training steps:", train_steps)
 
 

--- a/luke/utils/convert_luke_to_huggingface_model.py
+++ b/luke/utils/convert_luke_to_huggingface_model.py
@@ -9,23 +9,11 @@ from transformers.tokenization_utils_base import AddedToken
 
 
 @click.command()
-@click.argument("checkpoint-path", type=click.Path(exists=True), help="Path to a pytorch_model.bin file.")
-@click.argument(
-    "metadata-path", type=click.Path(exists=True), help="Path to a metadata.json file, defining the configuration."
-)
-@click.argument(
-    "entity-vocab-path",
-    type=click.Path(exists=True),
-    help="Path to an entity_vocab.tsv file, containing the entity vocabulary.",
-)
-@click.argument(
-    "transformers-model-save-path", type=click.Path(), help="Path to where to dump the output PyTorch model."
-)
-@click.argument(
-    "tokenizer-class",
-    type=click.Choice(["LukeTokenizer", "MLukeTokenizer"]),
-    help="The Tokenizer class to use in transformers.",
-)
+@click.argument("checkpoint-path", type=click.Path(exists=True))
+@click.argument("metadata-path", type=click.Path(exists=True))
+@click.argument("entity-vocab-path", type=click.Path(exists=True))
+@click.argument("transformers-model-save-path", type=click.Path())
+@click.argument("tokenizer-class", type=click.Choice(["LukeTokenizer", "MLukeTokenizer"]))
 def convert_luke_to_huggingface_model(
     checkpoint_path: str,
     metadata_path: str,

--- a/luke/utils/convert_luke_to_huggingface_model.py
+++ b/luke/utils/convert_luke_to_huggingface_model.py
@@ -9,11 +9,31 @@ from transformers.tokenization_utils_base import AddedToken
 
 
 @click.command()
-@click.argument("checkpoint-path", type=click.Path(exists=True))
-@click.argument("metadata-path", type=click.Path(exists=True))
-@click.argument("entity-vocab-path", type=click.Path(exists=True))
-@click.argument("transformers-model-save-path", type=click.Path())
-@click.argument("tokenizer-class", type=click.Choice(["LukeTokenizer", "MLukeTokenizer"]))
+@click.option("--checkpoint-path", type=click.Path(exists=True), help="Path to a pytorch_model.bin file.", required=True)
+@click.option(
+    "--metadata-path",
+    type=click.Path(exists=True),
+    help="Path to a metadata.json file, defining the configuration.",
+    required=True,
+)
+@click.option(
+    "--entity-vocab-path",
+    type=click.Path(exists=True),
+    help="Path to an entity_vocab.tsv file, containing the entity vocabulary.",
+    required=True,
+)
+@click.option(
+    "--transformers-model-save-path",
+    type=click.Path(),
+    help="Path to where to dump the output PyTorch model.",
+    required=True,
+)
+@click.option(
+    "--tokenizer-class",
+    type=click.Choice(["LukeTokenizer", "MLukeTokenizer"]),
+    help="The Tokenizer class to use in transformers.",
+    required=True,
+)
 def convert_luke_to_huggingface_model(
     checkpoint_path: str,
     metadata_path: str,

--- a/luke/utils/convert_luke_to_huggingface_model.py
+++ b/luke/utils/convert_luke_to_huggingface_model.py
@@ -1,0 +1,153 @@
+import json
+import os
+from collections import OrderedDict
+
+import click
+import torch
+from transformers import LukeConfig, LukeForMaskedLM, AutoTokenizer
+from transformers.tokenization_utils_base import AddedToken
+
+
+@click.command()
+@click.argument("checkpoint-path", type=click.Path(exists=True), help="Path to a pytorch_model.bin file.")
+@click.argument(
+    "metadata-path", type=click.Path(exists=True), help="Path to a metadata.json file, defining the configuration."
+)
+@click.argument(
+    "entity-vocab-path",
+    type=click.Path(exists=True),
+    help="Path to an entity_vocab.tsv file, containing the entity vocabulary.",
+)
+@click.argument(
+    "transformers-model-save-path", type=click.Path(), help="Path to where to dump the output PyTorch model."
+)
+@click.argument(
+    "tokenizer-class",
+    type=click.Choice(["LukeTokenizer", "MLukeTokenizer"]),
+    help="The Tokenizer class to use in transformers.",
+)
+def convert_luke_to_huggingface_model(
+    checkpoint_path: str,
+    metadata_path: str,
+    entity_vocab_path: str,
+    transformers_model_save_path: str,
+    tokenizer_class: str,
+):
+    # Load configuration defined in the metadata file
+    with open(metadata_path) as metadata_file:
+        metadata = json.load(metadata_file)
+    config = LukeConfig(use_entity_aware_attention=True, **metadata["model_config"])
+
+    # Load in the weights from the checkpoint_path
+    state_dict = torch.load(checkpoint_path, map_location="cpu")["module"]
+
+    # Load the entity vocab file
+    entity_vocab = load_original_entity_vocab(entity_vocab_path)
+    # add an entry for [MASK2]
+    entity_vocab["[MASK2]"] = max(entity_vocab.values()) + 1
+    config.entity_vocab_size += 1
+
+    tokenizer = AutoTokenizer.from_pretrained(metadata["model_config"]["bert_model_name"])
+
+    # Add special tokens to the token vocabulary for downstream tasks
+    entity_token_1 = AddedToken("<ent>", lstrip=False, rstrip=False)
+    entity_token_2 = AddedToken("<ent2>", lstrip=False, rstrip=False)
+    tokenizer.add_special_tokens(dict(additional_special_tokens=[entity_token_1, entity_token_2]))
+    config.vocab_size += 2
+
+    print(f"Saving tokenizer to {transformers_model_save_path}")
+    tokenizer.save_pretrained(transformers_model_save_path)
+    with open(os.path.join(transformers_model_save_path, "tokenizer_config.json"), "r") as f:
+        tokenizer_config = json.load(f)
+    tokenizer_config["tokenizer_class"] = tokenizer_class
+    with open(os.path.join(transformers_model_save_path, "tokenizer_config.json"), "w") as f:
+        json.dump(tokenizer_config, f)
+
+    with open(os.path.join(transformers_model_save_path, "entity_vocab.json"), "w") as f:
+        json.dump(entity_vocab, f)
+
+    tokenizer = AutoTokenizer.from_pretrained(transformers_model_save_path)
+
+    # Initialize the embeddings of the special tokens
+    ent_init_index = tokenizer.convert_tokens_to_ids(["@"])[0]
+    ent2_init_index = tokenizer.convert_tokens_to_ids(["#"])[0]
+
+    word_emb = state_dict["embeddings.word_embeddings.weight"]
+    ent_emb = word_emb[ent_init_index].unsqueeze(0)
+    ent2_emb = word_emb[ent2_init_index].unsqueeze(0)
+    state_dict["embeddings.word_embeddings.weight"] = torch.cat([word_emb, ent_emb, ent2_emb])
+    # add special tokens for 'entity_predictions.bias'
+    for bias_name in ["lm_head.decoder.bias", "lm_head.bias"]:
+        decoder_bias = state_dict[bias_name]
+        ent_decoder_bias = decoder_bias[ent_init_index].unsqueeze(0)
+        ent2_decoder_bias = decoder_bias[ent2_init_index].unsqueeze(0)
+        state_dict[bias_name] = torch.cat([decoder_bias, ent_decoder_bias, ent2_decoder_bias])
+
+    # Initialize the query layers of the entity-aware self-attention mechanism
+    for layer_index in range(config.num_hidden_layers):
+        for matrix_name in ["query.weight", "query.bias"]:
+            prefix = f"encoder.layer.{layer_index}.attention.self."
+            state_dict[prefix + "w2e_" + matrix_name] = state_dict[prefix + matrix_name]
+            state_dict[prefix + "e2w_" + matrix_name] = state_dict[prefix + matrix_name]
+            state_dict[prefix + "e2e_" + matrix_name] = state_dict[prefix + matrix_name]
+
+    # Initialize the embedding of the [MASK2] entity using that of the [MASK] entity for downstream tasks
+    entity_emb = state_dict["entity_embeddings.entity_embeddings.weight"]
+    entity_mask_emb = entity_emb[entity_vocab["[MASK]"]].unsqueeze(0)
+    state_dict["entity_embeddings.entity_embeddings.weight"] = torch.cat([entity_emb, entity_mask_emb])
+    # add [MASK2] for 'entity_predictions.bias'
+    entity_prediction_bias = state_dict["entity_predictions.bias"]
+    entity_mask_bias = entity_prediction_bias[entity_vocab["[MASK]"]].unsqueeze(0)
+    state_dict["entity_predictions.bias"] = torch.cat([entity_prediction_bias, entity_mask_bias])
+
+    model = LukeForMaskedLM(config=config).eval()
+
+    state_dict.pop("entity_predictions.decoder.weight")
+    state_dict.pop("lm_head.decoder.weight")
+    state_dict.pop("lm_head.decoder.bias")
+    state_dict_for_hugging_face = OrderedDict()
+    for key, value in state_dict.items():
+        if not (key.startswith("lm_head") or key.startswith("entity_predictions")):
+            state_dict_for_hugging_face[f"luke.{key}"] = state_dict[key]
+        else:
+            state_dict_for_hugging_face[key] = state_dict[key]
+
+    missing_keys, unexpected_keys = model.load_state_dict(state_dict_for_hugging_face, strict=False)
+
+    if set(unexpected_keys) != {"luke.embeddings.position_ids"}:
+        raise ValueError(f"Unexpected unexpected_keys: {unexpected_keys}")
+    if set(missing_keys) != {
+        "lm_head.decoder.weight",
+        "lm_head.decoder.bias",
+        "entity_predictions.decoder.weight",
+    }:
+        raise ValueError(f"Unexpected missing_keys: {missing_keys}")
+
+    model.tie_weights()
+    assert (model.luke.embeddings.word_embeddings.weight == model.lm_head.decoder.weight).all()
+    assert (model.luke.entity_embeddings.entity_embeddings.weight == model.entity_predictions.decoder.weight).all()
+
+    # Finally, save our PyTorch model and tokenizer
+    print("Saving PyTorch model to {}".format(transformers_model_save_path))
+    model.save_pretrained(transformers_model_save_path)
+
+
+def load_original_entity_vocab(entity_vocab_path):
+    SPECIAL_TOKENS = ["[MASK]", "[PAD]", "[UNK]"]
+
+    data = [json.loads(line) for line in open(entity_vocab_path)]
+
+    new_mapping = {}
+    for entry in data:
+        entity_id = entry["id"]
+        for entity_name, language in entry["entities"]:
+            if entity_name in SPECIAL_TOKENS:
+                new_mapping[entity_name] = entity_id
+                break
+            new_entity_name = f"{language}:{entity_name}"
+            new_mapping[new_entity_name] = entity_id
+    return new_mapping
+
+
+if __name__ == "__main__":
+    convert_luke_to_huggingface_model()

--- a/pretraining.md
+++ b/pretraining.md
@@ -223,4 +223,25 @@ deepspeed \
     --resume-checkpoint-id=<STAGE1_LAST_CHECKPOINT_DIR>
 ```
 
-## 7. Upload to HuggingFace Hub
+## 7. Use the pretrained model with HuggingFace Transformers
+The pretrained model can be used with the [transformers](https://github.com/huggingface/transformers) library after converting the checkpoint weights and metadata to the appropriate format.
+Specify the saved files and choose the appropriate tokenizer class (`--tokenizer-class`) from `LukeTokenizer` or `MLukeTokenizer`.
+
+```bash
+python luke/cli.py \
+    convert-luke-to-huggingface-model \ 
+    --checkpoint-path=<OUTPUT_DIR>/checkpoints/epoch20/mp_rank_00_model_states.pt \
+    --metadata-path=<OUTPUT_DIR>/metadata.json  \
+    --entity-vocab-path=<OUTPUT_DIR>/entity_vocab.jsonl \ 
+    --transformers-model-save-path=<TRANSFORMER_MODEL_SAVE_PATH> \ 
+    --tokenizer-class=<TOKENIZER_CLASS> 
+```
+
+Then you can load the model with transformers library.
+
+```python
+from transformers import AutoModel
+model = AutoModel.from_pretrained(TRANSFORMER_MODEL_SAVE_PATH)
+```
+
+Also, you can upload the model to the Hugging Face Hub by following the instructions [here](https://huggingface.co/docs/hub/adding-a-model).

--- a/pretraining.md
+++ b/pretraining.md
@@ -69,11 +69,9 @@ Download the latest wikidata dump from [here](https://dumps.wikimedia.org/wikida
 
 Example
 ```bash
-# this is the data used for our model
-# the link is out-of-date so please use the latest data instead
-wget https://dumps.wikimedia.org/wikidatawiki/entities/20201130/wikidata-20201130-all.json.bz2
+wget https://dumps.wikimedia.org/wikidatawiki/entities/latest-all.json.bz2
 
-python luke/cli.py build-interwiki-db wikidata-20201130-all.json.bz2 interwiki.db
+python luke/cli.py build-interwiki-db latest-all.json.bz2 interwiki.db
 ```
 
 Create entity vocabularies for each language and then combine them with the interwiki DB.


### PR DESCRIPTION
主な追加は `luke/utils/convert_luke_to_huggingface_model.py` と `pretraining.md` です。

* `luke/utils/convert_luke_to_huggingface_model.py`
transformers に入っている mLUKE 変換用スクリプトを click 仕様に置き換えて、モデルの重みが元モデルか確かめていた assert 文を削ったものです。

* `pretraining.md`
mLUKE の再現コマンドは bash 上で24言語分 for 文回すかたちで書きました。
Hugging Face Hub に上げるところの説明は、題名を Transformers で使うという趣旨に変えて、実際に Hugging Face Hub との連携は本家の説明に任せることにしました。