### PR TITLE
Set the default language of EntityVocab to None

### DIFF
--- a/luke/utils/entity_vocab.py
+++ b/luke/utils/entity_vocab.py
@@ -32,14 +32,15 @@ logger = logging.getLogger(__name__)
 @click.argument("out_file", type=click.Path())
 @click.option("--vocab-size", default=1000000)
 @click.option("--min-count", default=0)
+@click.option("--language", type=str)
 @click.option("-w", "--white-list", type=click.File(), multiple=True)
 @click.option("--white-list-only", is_flag=True)
 @click.option("--pool-size", default=multiprocessing.cpu_count())
 @click.option("--chunk-size", default=100)
-def build_entity_vocab(dump_db_file: str, white_list: List[TextIO], **kwargs):
+def build_entity_vocab(dump_db_file: str, white_list: List[TextIO], language: str, **kwargs):
     dump_db = DumpDB(dump_db_file)
     white_list = [line.rstrip() for f in white_list for line in f]
-    EntityVocab.build(dump_db, white_list=white_list, language=dump_db.language, **kwargs)
+    EntityVocab.build(dump_db, white_list=white_list, language=language, **kwargs)
 
 
 class EntityVocab:

--- a/pretraining.md
+++ b/pretraining.md
@@ -77,10 +77,10 @@ python luke/cli.py build-interwiki-db latest-all.json.bz2 interwiki.db
 Create entity vocabularies for each language and then combine them with the interwiki DB.
 ```bash
 for l in ar bn de nl el en es fi fr hi id it ja ko pl pt ru sv sw te th tr vi zh
-python luke/cli.py  build-entity-vocab "${l}wiki.db" "mluke_entity_vocab_${l}.jsonl"
+python luke/cli.py  build-entity-vocab "${l}wiki.db" "mluke_entity_vocab_${l}.jsonl" "--language ${l}" 
 
 
-COMMAND="python luke/cli.py vuild-interwiki-db -i interwiki.db -o mluke_entity_vocab.jsonl --vocab-size 1200000 --min-num-languages 3"
+COMMAND="python luke/cli.py build_multilingual_entity_vocab -i interwiki.db -o mluke_entity_vocab.jsonl --vocab-size 1200000 --min-num-languages 3"
 # add options by for loop because there are so many..
 for l in ar bn de nl el en es fi fr hi id it ja ko pl pt ru sv sw te th tr vi zh
 COMMAND=$COMMAND+" -v mluke_entity_vocab_${l}.jsonl"


### PR DESCRIPTION
When creating EntityVocab via `build-entity-vocab`...
- in monolingual settings, the language is set to None for backward compatibility
- in multilingual settings, the language has to be set to the language of the Wikipedia dump to align entities across languages later.

The current document seems to have issues around here.
In this pull request, we change the default behavior of `build-entity-vocab` to set the language to `None` and fix the document.

