### PR TITLE
Fix language param for while-list-only vocab build

### DIFF
--- a/examples/entity_disambiguation/README.md
+++ b/examples/entity_disambiguation/README.md
@@ -104,7 +104,8 @@ python luke/cli.py build-entity-vocab \
   enwiki.db \
   entity_vocab.jsonl \
   --white-list=candidates.txt \
-  --white-list-only
+  --white-list-only \
+  --language=en
 ```
 
 **4. Create training dataset**


### PR DESCRIPTION
If not setting language explicitly, all `lang` fields of entities in `entity_vocab.jsonl` will be left null, leading to https://github.com/studio-ousia/luke/blob/a40c580c5f1ad2f189dd02d195002921f6a4c994/luke/pretraining/dataset.py#L366 triggered exceptions since https://github.com/studio-ousia/luke/blob/a40c580c5f1ad2f189dd02d195002921f6a4c994/luke/pretraining/dataset.py#L317 gets `entity_id` by `DumpDB.lang`.