### PR TITLE
Add iob scheme option

### DIFF
--- a/examples/ner/README.md
+++ b/examples/ner/README.md
@@ -20,10 +20,10 @@ You may find the result a little higher than [the original paper of LUKE](https:
 ### mLUKE-large
 ```bash
 # Reproduce the result of studio-ousia/mluke-large-lite-finetuned-conll-2003
-python examples/ner/evaluate_transformers_checkpoint.py data/ner_conll/de/deu.testb.bio  studio-ousia/mluke-large-lite-finetuned-conll-2003 --cuda-device 0
+python examples/ner/evaluate_transformers_checkpoint.py data/ner_conll/de/deu.testb.bio  studio-ousia/mluke-large-lite-finetuned-conll-2003 --cuda-device 0 --iob-scheme iob2
 
 # When the input file has a file encoding different from utf-8, you should specify it with --file-encoding.
-python examples/ner/evaluate_transformers_checkpoint.py data/ner_conll/es/esp.testb studio-ousia/mluke-large-lite-finetuned-conll-2003 --cuda-device 0 --file-encoding ISO-8859-1
+python examples/ner/evaluate_transformers_checkpoint.py data/ner_conll/es/esp.testb studio-ousia/mluke-large-lite-finetuned-conll-2003 --cuda-device 0 --iob-scheme iob2 --file-encoding ISO-8859-1
 
 # Expected results for each language.
 # {"en": 94.1, "de": 78.8 "nl": 82.4 "es": 82.2", "average": 84.4}  

--- a/examples/ner/evaluate_transformers_checkpoint.py
+++ b/examples/ner/evaluate_transformers_checkpoint.py
@@ -36,6 +36,7 @@ tokenizer_name_mapping = {
 @click.option("--cuda-device", type=int, default=0)
 @click.option("--result-save-path", type=click.Path(exists=False), default=None)
 @click.option("--prediction-save-path", type=click.Path(exists=False), default=None)
+@click.option("--iob-scheme", type=str, default="iob1")
 @click.option("--file-encoding", type=str, default="utf-8")
 def evaluate_transformers_checkpoint(
     data_path: str,
@@ -46,6 +47,7 @@ def evaluate_transformers_checkpoint(
     cuda_device: int,
     result_save_path: str,
     prediction_save_path: str,
+    iob_scheme: str,
     file_encoding: str,
 ):
     """
@@ -63,6 +65,9 @@ def evaluate_transformers_checkpoint(
     batch_size : int
     cuda_device : int
     result_save_path : str
+    prediction_save_path: str
+    iob_scheme: str
+    file_encoding: str
     """
     import_module_and_submodules("examples")
 
@@ -77,6 +82,7 @@ def evaluate_transformers_checkpoint(
         ),
         token_indexers={"tokens": PretrainedTransformerIndexer(model_name=checkpoint_tokenizer_name)},
         use_entity_feature=True,
+        iob_scheme=iob_scheme,
         encoding=file_encoding,
     )
 


### PR DESCRIPTION
Related to #166, this PR adds `iob-scheme` option (default: `iob1`) to `examples/ner/evaluate_transformers_checkpoint.py` for easier reproduction of the experiments on CoNLL'03.