### PR TITLE
Fix entity_attention_mask for NER.

### DIFF
--- a/examples/ner/model.py
+++ b/examples/ner/model.py
@@ -43,11 +43,12 @@ class ExhaustiveNERModel(Model):
         labels: torch.LongTensor = None,
         entity_ids: torch.LongTensor = None,
         entity_position_ids: torch.LongTensor = None,
+        entity_attention_mask: torch.LongTensor = None,
         input_words: List[List[str]] = None,
         **kwargs,
     ):
         feature_vector = self.feature_extractor(
-            word_ids[self.text_field_key], entity_start_positions, entity_end_positions, entity_ids, entity_position_ids
+            word_ids[self.text_field_key], entity_start_positions, entity_end_positions, entity_ids, entity_position_ids, entity_attention_mask
         )
 
         feature_vector = self.dropout(feature_vector)

--- a/examples/ner/modules/entity_based.py
+++ b/examples/ner/modules/entity_based.py
@@ -24,11 +24,12 @@ class EntityBasedNERFeatureExtractor(NERFeatureExtractor):
         entity_end_positions: torch.LongTensor,
         entity_ids: torch.LongTensor = None,
         entity_position_ids: torch.LongTensor = None,
+        entity_attention_mask: torch.LongTensor = None,
     ):
 
         inputs["entity_ids"] = entity_ids
         inputs["entity_position_ids"] = entity_position_ids
-        inputs["entity_attention_mask"] = entity_ids != 0
+        inputs["entity_attention_mask"] = entity_attention_mask
 
         entity_embeddings = self.embedder(**inputs)
         return entity_embeddings

--- a/examples/ner/modules/feature_extractor.py
+++ b/examples/ner/modules/feature_extractor.py
@@ -23,5 +23,6 @@ class NERFeatureExtractor(Registrable, nn.Module):
         entity_end_positions: torch.LongTensor,
         entity_ids: torch.LongTensor = None,
         entity_position_ids: torch.LongTensor = None,
+        entity_attention_mask: torch.LongTensor = None,
     ) -> torch.Tensor:
         raise NotImplementedError

--- a/examples/ner/modules/token_and_entity.py
+++ b/examples/ner/modules/token_and_entity.py
@@ -24,11 +24,12 @@ class TokenEntityNERFeatureExtractor(NERFeatureExtractor):
         entity_end_positions: torch.LongTensor,
         entity_ids: torch.LongTensor = None,
         entity_position_ids: torch.LongTensor = None,
+        entity_attention_mask: torch.LongTensor = None,
     ):
 
         inputs["entity_ids"] = entity_ids
         inputs["entity_position_ids"] = entity_position_ids
-        inputs["entity_attention_mask"] = entity_ids != 0
+        inputs["entity_attention_mask"] = entity_attention_mask
 
         token_embeddings, entity_embeddings = self.embedder(**inputs)
         embedding_size = token_embeddings.size(-1)

--- a/examples/ner/modules/token_based.py
+++ b/examples/ner/modules/token_based.py
@@ -26,6 +26,7 @@ class TokenBasedNERFeatureExtractor(NERFeatureExtractor):
         entity_end_positions: torch.LongTensor,
         entity_ids: torch.LongTensor = None,
         entity_position_ids: torch.LongTensor = None,
+        entity_attention_mask: torch.LongTensor = None,
     ):
         token_embeddings = self.embedder(**inputs)
         token_embeddings = self.encoder(token_embeddings)

--- a/examples/ner/reader.py
+++ b/examples/ner/reader.py
@@ -97,8 +97,10 @@ class ConllSpanReader(DatasetReader):
 
         if isinstance(self.tokenizer.tokenizer, (LukeTokenizer, MLukeTokenizer)):
             self.entity_id = self.tokenizer.tokenizer.entity_vocab["[MASK]"]
+            self.entity_pad_id = self.tokenizer.tokenizer.entity_vocab["[PAD]"]
         else:
             self.entity_id = 1
+            self.entity_pad_id = 0
 
     def data_to_instance(self, words: List[str], labels: List[str], sentence_boundaries: List[int], doc_index: str):
         if self.tokenizer is None:
@@ -203,8 +205,9 @@ class ConllSpanReader(DatasetReader):
                 if self.use_entity_feature:
                     fields.update(
                         {
-                            "entity_ids": TensorField(np.array(entity_ids[start:end]), padding_value=0),
+                            "entity_ids": TensorField(np.array(entity_ids[start:end]), padding_value=self.entity_pad_id),
                             "entity_position_ids": TensorField(np.array(entity_position_ids[start:end])),
+                            "entity_attention_mask": TensorField(np.ones(len(entity_ids[start:end]), dtype=np.int64), padding_value=0),
                         }
                     )
 


### PR DESCRIPTION
Related to #166, this PR fixes `entity_attention_mask` for `examples/ner/evaluate_transformers_checkpoint.py`.