### PR TITLE
Fix huggingface_conll_2003 notebook.

### DIFF
--- a/notebooks/huggingface_conll_2003.ipynb
+++ b/notebooks/huggingface_conll_2003.ipynb
@@ -2577,7 +2577,7 @@
         "            original_word_spans = []\n",
         "            for word_start in range(len(sentence_words)):\n",
         "                for word_end in range(word_start, len(sentence_words)):\n",
-        "                    if sum(sentence_subword_lengths[word_start:word_end]) <= max_mention_length:\n",
+        "                    if sum(sentence_subword_lengths[word_start:word_end + 1]) <= max_mention_length:\n",
         "                        entity_spans.append(\n",
         "                            (word_start_char_positions[word_start], word_end_char_positions[word_end])\n",
         "                        )\n",


### PR DESCRIPTION
This PR fixes the calculation of max_mention_length in `huggingface_conll_2003.ipynb`.
(I did not re-run the notebook because it made many diffs.)